### PR TITLE
Skip image search if there are no images on a page

### DIFF
--- a/WikiApiObjectiveC/WikipediaHelper.m
+++ b/WikiApiObjectiveC/WikipediaHelper.m
@@ -76,28 +76,32 @@
         return htmlSrc;
     
     NSArray *splitonce = [formatedHtmlSrc componentsSeparatedByString:@"src=\""];
+    NSUInteger length =  [splitonce count];
+    if (length > 1) {
+        NSString *finalSplitString = [[NSString alloc]  initWithString:[splitonce objectAtIndex:1]];
+        NSArray *finalSplit = [finalSplitString  componentsSeparatedByString:@"\""];
 
-    NSString *finalSplitString = [[NSString alloc]  initWithString:[splitonce objectAtIndex:1]];
-    NSArray *finalSplit = [finalSplitString  componentsSeparatedByString:@"\""];
-
-    NSString *imageURL = [[NSString alloc]  initWithString:[finalSplit objectAtIndex:0]];
-    imageURL = [imageURL stringByTrimmingCharactersInSet:[NSCharacterSet  whitespaceCharacterSet]];
-
-    int i = 1;
-    
-    while([self isOnBlackList:imageURL]) { 
-        // Get the next image tag
-        finalSplitString = [[NSString alloc]  initWithString:[splitonce objectAtIndex:i]];
-        
-        finalSplit = [finalSplitString  componentsSeparatedByString:@"\""];
-        
-        imageURL = [[NSString alloc]  initWithString:[finalSplit objectAtIndex:0]];
+        NSString *imageURL = [[NSString alloc]  initWithString:[finalSplit objectAtIndex:0]];
         imageURL = [imageURL stringByTrimmingCharactersInSet:[NSCharacterSet  whitespaceCharacterSet]];
+
+        int i = 1;
         
-        i++;
-    }
+        while([self isOnBlackList:imageURL]) { 
+            // Get the next image tag
+            finalSplitString = [[NSString alloc]  initWithString:[splitonce objectAtIndex:i]];
+            
+            finalSplit = [finalSplitString  componentsSeparatedByString:@"\""];
+            
+            imageURL = [[NSString alloc]  initWithString:[finalSplit objectAtIndex:0]];
+            imageURL = [imageURL stringByTrimmingCharactersInSet:[NSCharacterSet  whitespaceCharacterSet]];
+            
+            i++;
+        }
     
-    return imageURL;
+        return imageURL;
+    } else {
+        return nil;
+    }
 }
 
 - (BOOL) isOnBlackList:(NSString *)imageURL {


### PR DESCRIPTION
When looking for the first image on a Wikipedia page with no images, `getUrlOfMainImage` throws an error `index 1 beyond bounds...`. presumably because there aren't any images in the newly-created array of images from the page's parsed HTML.

This just wraps the whole thing in a check to make sure there's something in the array before looping through it.
